### PR TITLE
Update install.sh, deletes miniconda installer if interrupted

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -103,8 +103,11 @@ install_miniconda() {
             ;;
     esac
 
+    # Clean existing Miniconda installer script
+    #rm -f /tmp/miniconda_installer.sh
+    
     # Download the Miniconda installer script
-    wget "https://repo.anaconda.com/miniconda/$miniconda_installer" -O /tmp/miniconda_installer.sh
+    wget -c "https://repo.anaconda.com/miniconda/$miniconda_installer" -O /tmp/miniconda_installer.sh
 
     # Run the installer script
     bash /tmp/miniconda_installer.sh -b -p "$HOME/miniconda"
@@ -116,7 +119,7 @@ install_miniconda() {
     source "$HOME/miniconda/etc/profile.d/conda.sh"
 
     # Clean up the Downloaded file
-    rm /tmp/miniconda_installer.sh
+    #rm -f /tmp/miniconda_installer.sh
 
     echo "Miniconda installed successfully in $HOME/miniconda"
 }


### PR DESCRIPTION
Potential errors could be avoided and resources can be saved if the miniconda installer is deleted before downloading it again.

This is in the case the script is interrupted before the download is completed.

I thought that it would be better if it instead checked if it was already there, just so it doesn't have to download it again, but that would cause issues in case the existing file is incomplete or corrupted