### PR TITLE
Start alltalk with the start_alltalk.bat script to fix cuda not available error

### DIFF
--- a/Launcher.bat
+++ b/Launcher.bat
@@ -1122,7 +1122,7 @@ call conda activate alltalk
 
 REM Start AllTalk
 echo %blue_bg%[%time%]%reset% %blue_fg_strong%[INFO]%reset% AllTalk launched in a new window.
-start cmd /k "title AllTalk && cd /d %~dp0voice-generation\alltalk_tts && python script.py"
+start cmd /k "title AllTalk && cd /d %~dp0voice-generation\alltalk_tts && start_alltalk.bat"
 goto :home
 
 


### PR DESCRIPTION
alltalk comes with a start_alltalk.bat script that properly prepares its environment. Running the naked python command, I get a cuda not available error
![image](https://github.com/SillyTavern/SillyTavern-Launcher/assets/4218386/d1cd8f05-4588-40f0-b9c8-52dbd121cd75)

starting it with the script, however, works fine.

![image](https://github.com/SillyTavern/SillyTavern-Launcher/assets/4218386/6e65e1d5-a5db-4fbb-939b-9692aba7c338)

Needs to either use start_alltalk.bat as in this pr or extend the init command to properly mirror what the batch file does