### PR TITLE
Fix launcher.sh bash script

### DIFF
--- a/launcher.sh
+++ b/launcher.sh
@@ -146,6 +146,9 @@ if [[ "$(git rev-list HEAD...origin/$current_branch)" ]]; then
   update_status="Update Available"
 fi
 
+# Go back to base dir
+cd ..
+
 ############################################################
 ################## HOME - FRONTEND #########################
 ############################################################
@@ -210,21 +213,30 @@ check_nodejs() {
 
 
 # Function to find a suitable terminal emulator
-find_terminal() {
-    for terminal in "$TERMINAL" x-terminal-emulator mate-terminal gnome-terminal terminator xfce4-terminal urxvt rxvt termit Eterm aterm uxterm xterm roxterm termite lxterminal terminology st qterminal lilyterm tilix terminix konsole kitty guake tilda alacritty hyper wezterm; do
+find_terminal()
+{
+    for term in "$TERM"
+    do
+        if command -v "$term" > /dev/null 2>&1; then
+            echo "$term"
+            return 0
+        fi
+    done
+    for terminal in "$TERMINAL"
+    do
         if command -v "$terminal" > /dev/null 2>&1; then
             echo "$terminal"
             return 0
         fi
     done
-
     # Return a default terminal if none is found
     echo "x-terminal-emulator"
     return 1
 }
 
 # Function to start SillyTavern
-start_st() {
+start_st()
+{
     check_nodejs
     #if LAUNCH_NEW_WIN is set to 0, SillyTavern will launch in the same window
     if [ "$LAUNCH_NEW_WIN" = "0" ]; then
@@ -339,41 +351,43 @@ start_xtts() {
 update() {
     echo -e "\033]0;SillyTavern [UPDATE]\007"
     log_message "INFO" "Updating SillyTavern-Launcher..."
-    cd "$(dirname "$0")"
     git pull --rebase --autostash
 
     # Update SillyTavern if directory exists
-    if [ -d "$(dirname "$0")/SillyTavern" ]; then
+    if [ -d "./SillyTavern" ]; then
         log_message "INFO" "Updating SillyTavern..."
-        cd "$(dirname "$0")./SillyTavern"
+        cd "SillyTavern"
         git pull --rebase --autostash
+        cd ..
         log_message "INFO" "SillyTavern updated successfully."
     else
         log_message "WARN" "SillyTavern directory not found. Skipping SillyTavern update."
     fi
 
     # Update Extras if directory exists
-    if [ -d "$(dirname "$0")/SillyTavern-extras" ]; then
+    if [ -d "./SillyTavern-extras" ]; then
         log_message "INFO" "Updating SillyTavern-extras..."
-        cd "$(dirname "$0")./SillyTavern-extras"
+        cd "SillyTavern-extras"
         git pull --rebase --autostash
+        cd ..
         log_message "INFO" "SillyTavern-extras updated successfully."
     else
         log_message "WARN" "SillyTavern-extras directory not found. Skipping SillyTavern-extras update."
     fi
 
     # Update XTTS if directory exists
-    if [ -d "$(dirname "$0")/xtts" ]; then
+    if [ -d "./xtts" ]; then
         log_message "INFO" "Updating XTTS..."
-        cd "$(dirname "$0")./xtts"
+        cd "xtts"
         source activate xtts
-        pip install --upgrade xtts-api-server
+        install --upgrade xtts-api-server
         conda deactivate
+        cd ..
         log_message "INFO" "XTTS updated successfully."
     else
         log_message "WARN" "xtts directory not found. Skipping XTTS update."
     fi
-
+    cd "$(dirname "$0")"
     read -p "Press Enter to continue..."
     home
 }

--- a/launcher.sh
+++ b/launcher.sh
@@ -240,7 +240,7 @@ start_st()
     #if LAUNCH_NEW_WIN is set to 0, SillyTavern will launch in the same window
     if [ "$LAUNCH_NEW_WIN" = "0" ]; then
         log_message "INFO" "SillyTavern launched"
-        cd "$(dirname "$0")./SillyTavern" || exit 1
+        cd "SillyTavern" || exit 1
         ./start.sh
     else
         log_message "INFO" "SillyTavern launched in a new window."
@@ -254,9 +254,9 @@ start_st()
         # Start SillyTavern in the detected terminal
         if [ "$(uname)" == "Darwin" ]; then
             log_message "INFO" "Detected macOS. Opening new Terminal window."
-            open -a Terminal "$(dirname "$0")/start.sh"
+            open -a Terminal "start.sh"
         else
-            exec "$detected_terminal" -e "cd $(dirname "$0")./SillyTavern && ./start.sh" &
+            exec "$detected_terminal" -e "cd SillyTavern && ./start.sh" &
         fi
     fi
 
@@ -271,7 +271,7 @@ start_extras() {
         log_message "INFO" "Extras launched under pid $main_pid"
         {
             #has to be after the first one, so we are 1 directory up
-            cd "$(dirname "$0")./SillyTavern-extras" || {
+            cd "SillyTavern-extras" || {
                 log_message "ERROR" "SillyTavern-extras directory not found. Please make sure you have installed SillyTavern-extras."
                 kill $main_pid
                 exit 1
@@ -295,9 +295,9 @@ start_extras() {
         # Start SillyTavern in the detected terminal
         if [ "$(uname)" == "Darwin" ]; then
             log_message "INFO" "Detected macOS. Opening new Terminal window."
-            open -a Terminal --args --title="SillyTavern Extras" --working-directory="$(dirname "$0")/SillyTavern-extras" --command "conda activate xtts; python server.py --listen --rvc-save-file --max-content-length=1000 --enable-modules=rvc,caption; exec bash"
+            open -a Terminal --args --title="SillyTavern Extras" --working-directory="SillyTavern-extras" --command "conda activate xtts; python server.py --listen --rvc-save-file --max-content-length=1000 --enable-modules=rvc,caption; exec bash"
         else
-            exec "$detected_terminal" -e "cd '$(dirname "$0")/SillyTavern-extras' && conda activate extras && python server.py --listen --rvc-save-file --max-content-length=1000 --enable-modules=rvc,caption; bash"
+            exec "$detected_terminal" -e "cd 'SillyTavern-extras' && conda activate extras && python server.py --listen --rvc-save-file --max-content-length=1000 --enable-modules=rvc,caption; bash"
         fi
     fi
     home
@@ -312,7 +312,7 @@ start_xtts() {
         log_message "INFO" "xtts launched under pid $main_pid"
 
         # Move to xtts directory
-        cd "$(dirname "$0")/xtts" || {
+        cd "xtts" || {
             log_message "ERROR" "xtts directory not found. Please make sure you have installed xtts"
             kill "$main_pid"
             exit 1
@@ -337,9 +337,9 @@ start_xtts() {
         # Start XTTS in the detected terminal
         if [ "$(uname)" == "Darwin" ]; then
             log_message "INFO" "Detected macOS. Opening new Terminal window."
-            open -a Terminal --args --title="XTTSv2 API Server" --working-directory="$(dirname "$0")/xtts" --command "conda activate xtts; python -m xtts_api_server; exec bash"
+            open -a Terminal --args --title="XTTSv2 API Server" --working-directory="xtts" --command "conda activate xtts; python -m xtts_api_server; exec bash"
         else
-            exec "$detected_terminal" -e "cd '$(dirname "$0")/xtts' && conda activate xtts && python -m xtts_api_server; bash"
+            exec "$detected_terminal" -e "cd 'xtts' && conda activate xtts && python -m xtts_api_server; bash"
         fi
     fi
     home
@@ -386,7 +386,6 @@ update() {
     else
         log_message "WARN" "xtts directory not found. Skipping XTTS update."
     fi
-    cd "$(dirname "$0")"
     read -p "Press Enter to continue..."
     home
 }
@@ -700,7 +699,6 @@ uninstall_extras() {
     read confirmation
 
     if [ "$confirmation" = "Y" ] || [ "$confirmation" = "y" ]; then
-        cd "$(dirname "$0")"
         log_message "INFO" "Removing the SillyTavern-extras directory..."
         rm -rf SillyTavern-extras
         log_message "INFO" "Removing the Conda environment: extras"
@@ -726,7 +724,6 @@ uninstall_xtts() {
     read confirmation
 
     if [ "$confirmation" = "Y" ] || [ "$confirmation" = "y" ]; then
-        cd "$(dirname "$0")"
         log_message "INFO" "Removing the xtts directory..."
         rm -rf xtts
         log_message "INFO" "Removing the Conda environment: xtts"
@@ -754,7 +751,6 @@ uninstall_st() {
     read confirmation
 
     if [ "$confirmation" = "Y" ] || [ "$confirmation" = "y" ]; then
-        cd "$(dirname "$0")"
         log_message "INFO" "Removing the SillyTavern directory..."
         rm -rf SillyTavern
         log_message "INFO" "${green_fg_strong}SillyTavern uninstalled successfully.${reset}"

--- a/launcher.sh
+++ b/launcher.sh
@@ -131,10 +131,8 @@ install_git() {
         echo -e "${blue_fg_strong}[INFO] Git is already installed.${reset}"
     fi
 }
-#cd to base dir first
-cd "$(dirname "$0")"
 # Change the current directory to 'sillytavern' folder
-cd "SillyTavern" || exit 1
+cd "$(dirname "$0")/SillyTavern" || exit 1
 
 # Check for updates
 git fetch origin

--- a/launcher.sh
+++ b/launcher.sh
@@ -380,7 +380,7 @@ update() {
         log_message "INFO" "Updating XTTS..."
         cd "xtts"
         source activate xtts
-        install --upgrade xtts-api-server
+        pip install --upgrade xtts-api-server
         conda deactivate
         cd ..
         log_message "INFO" "XTTS updated successfully."

--- a/launcher.sh
+++ b/launcher.sh
@@ -131,7 +131,8 @@ install_git() {
         echo -e "${blue_fg_strong}[INFO] Git is already installed.${reset}"
     fi
 }
-
+#cd to base dir first
+cd "$(dirname "$0")"
 # Change the current directory to 'sillytavern' folder
 cd "SillyTavern" || exit 1
 

--- a/launcher.sh
+++ b/launcher.sh
@@ -354,7 +354,7 @@ update() {
     git pull --rebase --autostash
 
     # Update SillyTavern if directory exists
-    if [ -d "./SillyTavern" ]; then
+    if [ -d "SillyTavern" ]; then
         log_message "INFO" "Updating SillyTavern..."
         cd "SillyTavern"
         git pull --rebase --autostash
@@ -365,7 +365,7 @@ update() {
     fi
 
     # Update Extras if directory exists
-    if [ -d "./SillyTavern-extras" ]; then
+    if [ -d "SillyTavern-extras" ]; then
         log_message "INFO" "Updating SillyTavern-extras..."
         cd "SillyTavern-extras"
         git pull --rebase --autostash
@@ -376,7 +376,7 @@ update() {
     fi
 
     # Update XTTS if directory exists
-    if [ -d "./xtts" ]; then
+    if [ -d "xtts" ]; then
         log_message "INFO" "Updating XTTS..."
         cd "xtts"
         source activate xtts

--- a/launcher.sh
+++ b/launcher.sh
@@ -243,6 +243,7 @@ start_st()
         cd "SillyTavern" || exit 1
         ./start.sh
     else
+        cd "SillyTavern" || exit 1
         log_message "INFO" "SillyTavern launched in a new window."
         # Find a suitable terminal
         local detected_terminal
@@ -256,7 +257,7 @@ start_st()
             log_message "INFO" "Detected macOS. Opening new Terminal window."
             open -a Terminal "start.sh"
         else
-            exec "$detected_terminal" -e "cd SillyTavern && ./start.sh" &
+            exec "$detected_terminal" -e "./start.sh" &
         fi
     fi
 
@@ -276,7 +277,7 @@ start_extras() {
                 kill $main_pid
                 exit 1
             }
-            log_message "INFO" "Wordking dir: $(pwd)"
+            log_message "INFO" "Working dir: $(pwd)"
             ./start.sh
         } &
         local extras_pid=$!
@@ -284,6 +285,7 @@ start_extras() {
         wait $main_pid
         kill $extras_pid
     else
+        cd "SillyTavern-extras"
         log_message "INFO" "Extras launched in a new window."
         # Find a suitable terminal
         local detected_terminal
@@ -295,9 +297,9 @@ start_extras() {
         # Start SillyTavern in the detected terminal
         if [ "$(uname)" == "Darwin" ]; then
             log_message "INFO" "Detected macOS. Opening new Terminal window."
-            open -a Terminal --args --title="SillyTavern Extras" --working-directory="SillyTavern-extras" --command "conda activate xtts; python server.py --listen --rvc-save-file --max-content-length=1000 --enable-modules=rvc,caption; exec bash"
+            open -a Terminal --args --title="SillyTavern Extras" --working-directory="SillyTavern-extras" --command "python server.py --listen --rvc-save-file --max-content-length=1000 --enable-modules=rvc,caption; exec bash"
         else
-            exec "$detected_terminal" -e "cd 'SillyTavern-extras' && conda activate extras && python server.py --listen --rvc-save-file --max-content-length=1000 --enable-modules=rvc,caption; bash"
+            exec "$detected_terminal" -e "python server.py --listen --rvc-save-file --max-content-length=1000 --enable-modules=rvc,caption; bash"
         fi
     fi
     home
@@ -326,6 +328,7 @@ start_xtts() {
         wait "$main_pid"
         kill "$xtts_pid"
     else
+        cd "xtts"
         log_message "INFO" "xtts launched in a new window."
         # Find a suitable terminal
         local detected_terminal
@@ -339,7 +342,7 @@ start_xtts() {
             log_message "INFO" "Detected macOS. Opening new Terminal window."
             open -a Terminal --args --title="XTTSv2 API Server" --working-directory="xtts" --command "conda activate xtts; python -m xtts_api_server; exec bash"
         else
-            exec "$detected_terminal" -e "cd 'xtts' && conda activate xtts && python -m xtts_api_server; bash"
+            exec "$detected_terminal" -e "conda activate xtts && python -m xtts_api_server; bash"
         fi
     fi
     home


### PR DESCRIPTION
This changes the launcher.sh bash script and fixes updating and finding a terminal.


The broken updating was caused by the script being in the SillyTavern subdirectory because of cd'ing into it at line 136, as well as incorrect cd parameters in the update function after finding the directory because if we are already in the script's directory `$(dirname "$0")` outputs `.`, I also simplified the if statements in the update() function and made it cd out back to the main SillyTavern-Launcher so it can proceed with the next update step.


The seldom working terminal finding which always fell back to xterm was caused by the script looking at the $TERMINAL env var, I added to the find_terminal() function so that it also looks in the much more common $TERM env var first and then in $TERMINAL.

It also fixes random issues that I find that shouldn't happen but happen because of one reason or another.