### PR TITLE
Added ST node server logging and automatic fixing for Node Module Errors

### DIFF
--- a/log_wrapper.bat
+++ b/log_wrapper.bat
@@ -1,0 +1,24 @@
+@echo off
+setlocal
+
+REM Define the path to the log file
+set LOG_FILE=..\bin\st_console_output.log
+
+REM Set necessary environment variables for Node.js
+set NODE_ENV=production
+
+REM Determine the command to run
+if "%1"=="ssl" (
+    set NODE_CMD=node server.js --ssl
+) else (
+    set NODE_CMD=node server.js
+)
+
+REM Start the Node.js server and log the output using PowerShell Tee-Object, suppressing specific warnings
+echo Starting Node.js server with command: %NODE_CMD%
+powershell -Command "& {%NODE_CMD% 2>&1 | Where-Object {$_ -notmatch 'Security has been overridden'} | Tee-Object -FilePath '%LOG_FILE%'}"
+echo Node.js server started.
+pause
+
+REM Pause to keep the window open
+pause


### PR DESCRIPTION
Logs ST node server console output to file, scans the log for node module errors, if found prompts user to run the troubleshooter for an auto-fix. To be able to have both console output and logging to file without making a SillyTavern pull request a new intermediary bat had to be added: log_wrapper.bat