### PR TITLE
Shut npm install

### DIFF
--- a/Launcher.bat
+++ b/Launcher.bat
@@ -4663,7 +4663,7 @@ if %errorlevel% neq 0 (
     goto :home
 )
 echo %blue_bg%[%time%]%reset% %blue_fg_strong%[INFO]%reset% SillyTavern launched in a new window.
-start cmd /k "title SillyTavern && cd /d %st_install_path% && call npm install --no-audit && node server.js && pause && popd"
+start cmd /k "title SillyTavern && cd /d %st_install_path% && call npm install --no-audit --no-fund --loglevel=error --no-progress --omit=dev && node server.js && pause && popd"
 
 if exist "%~dp0bin\settings\custom-shortcut.txt" (
     setlocal EnableDelayedExpansion

--- a/bin/functions/Toolbox/App_Launcher/Core_Utilities/start_st.bat
+++ b/bin/functions/Toolbox/App_Launcher/Core_Utilities/start_st.bat
@@ -42,10 +42,10 @@ if exist "%SSL_INFO_FILE%" (
 :ST_SSL_Start
 if "%sslPathsFound%"=="true" (
     echo %blue_bg%[%time%]%reset% %blue_fg_strong%[INFO]%reset% SillyTavern opened with SSL in a new window.
-    start cmd /k "title SillyTavern && cd /d %st_install_path% && call npm install --no-audit && call %functions_dir%\Home\log_wrapper.bat ssl"
+    start cmd /k "title SillyTavern && cd /d %st_install_path% && call npm install --no-audit --no-fund --loglevel=error --no-progress --omit=dev && call %functions_dir%\Home\log_wrapper.bat ssl"
 ) else (
     echo %blue_bg%[%time%]%reset% %blue_fg_strong%[INFO]%reset% SillyTavern opened in a new window.
-    start cmd /k "title SillyTavern && cd /d %st_install_path% && call npm install --no-audit && call %functions_dir%\Home\log_wrapper.bat"
+    start cmd /k "title SillyTavern && cd /d %st_install_path% && call npm install --no-audit --no-fund --loglevel=error --no-progress --omit=dev && call %functions_dir%\Home\log_wrapper.bat"
 )
 
 REM Clear the old log file if it exists
@@ -72,7 +72,7 @@ goto :scan_log
 :fallback
 REM Fallback to %st_install_path% and start
 echo %blue_bg%[%time%]%reset% %blue_fg_strong%[INFO]%reset% Fallback: Starting SillyTavern from %st_install_path%...
-start cmd /k "title SillyTavern && cd /d %st_install_path% && call npm install --no-audit && call Start.bat"
+start cmd /k "title SillyTavern && cd /d %st_install_path% && call npm install --no-audit --no-fund --loglevel=error --no-progress --omit=dev && call Start.bat"
 echo %blue_bg%[%time%]%reset% %blue_fg_strong%[INFO]%reset% SillyTavern should now be launching in a new window, if you still receive errors please contact the launcher devs in the #launcher-help channel on discord.
 timeout /t 10
 exit /b 1

--- a/bin/functions/Toolbox/App_Launcher/Core_Utilities/update_start_st.bat
+++ b/bin/functions/Toolbox/App_Launcher/Core_Utilities/update_start_st.bat
@@ -62,10 +62,10 @@ if exist "%SSL_INFO_FILE%" (
 :ST_SSL_Start
 if "%sslPathsFound%"=="true" (
     echo %blue_bg%[%time%]%reset% %blue_fg_strong%[INFO]%reset% SillyTavern opened with SSL in a new window.
-    start cmd /k "title SillyTavern && cd /d %st_install_path% && call npm install --no-audit && call %functions_dir%\Home\log_wrapper.bat ssl"
+    start cmd /k "title SillyTavern && cd /d %st_install_path% && call npm install --no-audit --no-fund --loglevel=error --no-progress --omit=dev && call %functions_dir%\Home\log_wrapper.bat ssl"
 ) else (
     echo %blue_bg%[%time%]%reset% %blue_fg_strong%[INFO]%reset% SillyTavern opened in a new window.
-    start cmd /k "title SillyTavern && cd /d %st_install_path% && call npm install --no-audit && call %functions_dir%\Home\log_wrapper.bat"
+    start cmd /k "title SillyTavern && cd /d %st_install_path% && call npm install --no-audit --no-fund --loglevel=error --no-progress --omit=dev && call %functions_dir%\Home\log_wrapper.bat"
 )
 
 REM Clear the old log file if it exists


### PR DESCRIPTION
See https://github.com/SillyTavern/SillyTavern/issues/2876

1. Hides everything from the `npm install` process beside errors.
2. Omits the installation of development-only packages (primarily `eslint`).