### PR TITLE
[BUG] Dual GPU displaying incorrect VRAM (and preventing models from being downloaded via launcher)

### DIFF
--- a/Launcher.bat
+++ b/Launcher.bat
@@ -428,8 +428,30 @@ if not exist "%st_install_path%" (
 )
 
 REM Run PowerShell command to retrieve VRAM size and divide by 1GB
-for /f "usebackq tokens=*" %%i in (`powershell -Command "$qwMemorySize = (Get-ItemProperty -Path 'HKLM:\SYSTEM\ControlSet001\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}\0*' -Name HardwareInformation.qwMemorySize -ErrorAction SilentlyContinue).'HardwareInformation.qwMemorySize'; if ($null -ne $qwMemorySize -and $qwMemorySize -is [array]) { $qwMemorySize = [double]$qwMemorySize[0] } else { $qwMemorySize = [double]$qwMemorySize }; if ($null -ne $qwMemorySize) { [math]::Round($qwMemorySize/1GB) } else { 'Property not found' }"`) do (
-    set "UVRAM=%%i"
+set /a iteration=0
+set /a last_UVRAM=0
+REM Detect GPU and store name, excluding integrated GPUs if discrete GPUs are found
+for /f "tokens=2 delims==" %%f in ('wmic path Win32_VideoController get name /value ^| find "="') do (
+	REM Run PowerShell command to retrieve VRAM size and divide by 1GB
+	for /f "usebackq tokens=*" %%i in (`powershell -Command "$qwMemorySize = (Get-ItemProperty -Path 'HKLM:\SYSTEM\ControlSet001\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}\0*' -Name HardwareInformation.qwMemorySize -ErrorAction SilentlyContinue).'HardwareInformation.qwMemorySize'; if ($null -ne $qwMemorySize -and $qwMemorySize -is [array]) { $qwMemorySize = [double]$qwMemorySize[!iteration!] } else { $qwMemorySize = [double]$qwMemorySize }; if ($null -ne $qwMemorySize) { [math]::Round($qwMemorySize/1GB) } else { 'Property not found' }"`) do (
+		set "UVRAM=%%i"
+	)
+	set /a iteration=!iteration!+1
+	REM If the VRAM is greater than 0 (it always should be, but just in case...) AND the lastUVRAM is not the same as VRAM
+	REM (might have to change this in the case where two cards have the same VRAM, but the user wants the first card...
+	REM in which case we would want to see if it is the first iteration or not... but I'm not here to do all your work!)
+	REM AND the lastUVRAM is Grt than VRAM... set it to the previous card. We don't have to check the other way, because
+	REM we already set VRAM. This way takes more builds into account... but not all.
+	if /i !lastUVRAM! gtr 0 (
+		if /i !lastUVRAM! neq !UVRAM! (
+			if /i !lastUVRAM! gtr !UVRAM! (
+				set "UVRAM=!lastUVRAM!"
+				set "GPU_name=!last_GPU!"
+			)
+		)
+	) else (
+		set "lastUVRAM=!UVRAM!"
+	)
 )
 
 REM Change the current directory to 'sillytavern' folder

--- a/bin/functions/Toolbox/Troubleshooting/gpu_info.bat
+++ b/bin/functions/Toolbox/Troubleshooting/gpu_info.bat
@@ -2,32 +2,46 @@
 
 REM Initialize variables
 setlocal enabledelayedexpansion
+set /a iteration=0
+set /a last_VRAM=0
+set "last_GPU=Unknown"
 set "GPU_name=Unknown"
 set "VRAM=Unknown"
 set "primary_gpu_found=false"
-
 REM Detect GPU and store name, excluding integrated GPUs if discrete GPUs are found
-for /f "tokens=2 delims==" %%f in ('wmic path Win32_VideoController where "AdapterRAM > 0" get name /value ^| find "="') do (
-    set "current_gpu=%%f"
-    if /i "!current_gpu!" neq "Microsoft Basic Display Adapter" (
-        if /i "!current_gpu!" neq "Intel(R) HD Graphics" (
-            set "GPU_name=!current_gpu!"
-            set "primary_gpu_found=true"
-            goto :vram_check
-        )
-    ) else if "!primary_gpu_found!" equ "false" (
-        set "GPU_name=!current_gpu!"
-        goto :vram_check
-    )
-)
-
-:vram_check
-REM Run PowerShell command to retrieve VRAM size and divide by 1GB
-for /f "usebackq tokens=*" %%i in (`powershell -Command "$qwMemorySize = (Get-ItemProperty -Path 'HKLM:\SYSTEM\ControlSet001\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}\0*' -Name HardwareInformation.qwMemorySize -ErrorAction SilentlyContinue).'HardwareInformation.qwMemorySize'; if ($null -ne $qwMemorySize -and $qwMemorySize -is [array]) { $qwMemorySize = [double]$qwMemorySize[0] } else { $qwMemorySize = [double]$qwMemorySize }; if ($null -ne $qwMemorySize) { [math]::Round($qwMemorySize/1GB) } else { 'Property not found' }"`) do (
-    set "VRAM=%%i"
+for /f "tokens=2 delims==" %%f in ('wmic path Win32_VideoController get name /value ^| find "="') do (
+	REM If GPU name is blank, set it; else, if it is not blank and does not equal the current value of f,
+	REM move gpu name to last_gpu and set gpu_name to the new value. This is here so that if the current card has less
+	REM VRAM than the previous card, we can set the name back properly. I doubt it would be needed... but you never know.
+	if /i !GPU_name! equ "" (
+		set "GPU_name=%%f"
+	) else if !GPU_name! neq %%f (
+		set "last_GPU=!GPU_name!"
+		set "GPU_name=%%f"
+	)
+	REM Run PowerShell command to retrieve VRAM size and divide by 1GB
+	for /f "usebackq tokens=*" %%i in (`powershell -Command "$qwMemorySize = (Get-ItemProperty -Path 'HKLM:\SYSTEM\ControlSet001\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}\0*' -Name HardwareInformation.qwMemorySize -ErrorAction SilentlyContinue).'HardwareInformation.qwMemorySize'; if ($null -ne $qwMemorySize -and $qwMemorySize -is [array]) { $qwMemorySize = [double]$qwMemorySize[!iteration!] } else { $qwMemorySize = [double]$qwMemorySize }; if ($null -ne $qwMemorySize) { [math]::Round($qwMemorySize/1GB) } else { 'Property not found' }"`) do (
+		set "VRAM=%%i"
+	)
+	REM iterate so we can move through the objects in the powershell script...
+	set /a iteration=!iteration!+1
+	REM If the VRAM is greater than 0 (it always should be, but just in case...) AND the lastVRAM is not the same as VRAM
+	REM (might have to change this in the case where two cards have the same VRAM, but the user wants the first card...
+	REM in which case we would want to see if it is the first iteration or not... but I'm not here to do all your work!)
+	REM AND the lastVRAM is Grt than VRAM... set it to the previous card. We don't have to check the other way, because
+	REM we already set VRAM. This way takes more builds into account... but not all.
+	if /i !lastVRAM! gtr 0 (
+		if /i !lastVRAM! neq !VRAM! (
+			if /i !lastVRAM! gtr !VRAM! (
+				set "VRAM=!lastVRAM!"
+				set "GPU_name=!last_GPU!"
+			)
+		)
+	) else (
+		set "lastVRAM=!VRAM!"
+	)
 )
 
 REM Display GPU name and VRAM
 echo GPU: %cyan_fg_strong%%GPU_name%%reset% - VRAM: %cyan_fg_strong%%VRAM%%reset% GB
-
 endlocal


### PR DESCRIPTION
This adds changes to Launcher.bat and gpu_info.bat to allow them to iterate through the GPUs on a system and pick the one with the most VRAM... from among the last two GPUs on the system. If you have more than two GPUs... say three... and the first one is one with the most VRAM, you will be out of luck. Because this picks from among the last two.

What should be changed... is that it needs to be made into a list and have the list compared to see which is the better performer, then select based on that result. I will probably figure out how to do that in a couple days.


(New pull request because I am silly and don't know how git hub works, so I'm worried my proposed changes would overwrite the recent update... so I made a new fork with the updates and now this pull request...) I think I did it right?