### PR TITLE
Return to parent directory after launching/before returning home

### DIFF
--- a/launcher.sh
+++ b/launcher.sh
@@ -261,6 +261,7 @@ start_st()
         fi
     fi
 
+    cd ..
     home
 }
 

--- a/launcher.sh
+++ b/launcher.sh
@@ -237,13 +237,13 @@ find_terminal()
 start_st()
 {
     check_nodejs
+    cd "SillyTavern" || exit 1
+
     #if LAUNCH_NEW_WIN is set to 0, SillyTavern will launch in the same window
     if [ "$LAUNCH_NEW_WIN" = "0" ]; then
         log_message "INFO" "SillyTavern launched"
-        cd "SillyTavern" || exit 1
         ./start.sh
     else
-        cd "SillyTavern" || exit 1
         log_message "INFO" "SillyTavern launched in a new window."
         # Find a suitable terminal
         local detected_terminal


### PR DESCRIPTION
Noticed that after changing into and launching SillyTavern, the launcher script doesn't change back to the parent directory. Thus, when the user tries to launch again (assuming they terminated SillyTavern), it tries to change in into the SillyTavern from the SillyTavern directory and exits with something like `./launcher.sh: line 243: cd: SillyTavern: No such file or directory`

I just threw in a `cd ..` like I saw in other functions - optionally, in my second commit, we might rearrange the `cd "SillyTavern"`'s to make it clearer that the if blocks take place *in* the SillyTavern directory.