### PR TITLE
Add executables in `bin/` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ xtts/
 
 !bin/functions/
 !bin/functions/**
+bin/*.exe
 bin/logs
 bin/settings
 *.txt


### PR DESCRIPTION
I added `bin/*.exe` to gitignore, since the `bin/` directory has `git.exe` as a file when I clone the SillyTavern Launcher repository. Closes #108 