### PR TITLE
Fix path regex compatibility with Bash 5.3

### DIFF
--- a/launcher.sh
+++ b/launcher.sh
@@ -3272,7 +3272,8 @@ check_path_spaces() {
 
 # Function to check if the folder path has no special characters
 check_path_special_chars() {
-    if [[ "$PWD" =~ [\!\#\$\%\&\*\+\,\;\<\=\>\?\@\[\]\^\`\{\|\}\~] ]]; then
+    local special_chars_re='[][!#$%&*+,;<=>?@^`{|}~]'
+    if [[ $PWD =~ $special_chars_re ]]; then
         log_message "ERROR" "${red_fg_strong}Path cannot have special characters! Please remove them.${reset}"
         log_message "ERROR" "Folders containing special characters make the launcher unstable."
         log_message "ERROR" "Path: ${red_fg_strong}$PWD${reset}"


### PR DESCRIPTION
## Summary

- Replace the inline path-validation regex with a valid POSIX ERE stored in a shell variable.
- Preserve the same 22 forbidden path characters.
- Avoid a runtime `invalid regular expression` failure on GNU Bash 5.3.

## Root cause

`launcher.sh` used this expression in `check_path_special_chars`:

```bash
[[ "$PWD" =~ [\!\#\$\%\&\*\+\,\;\<\=\>\?\@\[\]\^\`\{\|\}\~] ]]
```

On GNU Bash 5.3.9, the regex backend rejects the escaped braces inside the bracket expression with:

```text
invalid regular expression ... Invalid content of \{\}
```

`bash -n launcher.sh` does not report the problem because `-n` validates shell syntax without executing commands. The right-hand side of `[[ string =~ regex ]]` is compiled by Bash's regex engine only when that conditional executes, so the script can pass the syntax check and still fail at startup.

The error appeared in a Zsh terminal, but Zsh was not parsing this expression during normal `./launcher.sh` execution. The script has a `#!/bin/bash` shebang, so Zsh launched Bash as the child interpreter and displayed Bash's runtime diagnostic on the terminal. Sourcing the launcher into Zsh would be a separate, unsupported execution mode.

## Fix

Store a standards-compliant bracket expression in a single-quoted variable and pass that variable to `=~`:

```bash
local special_chars_re='[][!#$%&*+,;<=>?@^`{|}~]'
if [[ $PWD =~ $special_chars_re ]]; then
```

Placing `]` first makes it literal inside the bracket expression. The braces are already literal inside the class and must not be escaped. Keeping the regex in a single-quoted variable also avoids shell-parser ambiguity around the punctuation.

## Verification

No canonical launcher test suite was detected, so I ran focused behavioral verification against the function extracted from the modified `launcher.sh`:

- `bash -n launcher.sh`
- `git diff --check`
- Confirmed a normal path is accepted
- Confirmed all 22 intended forbidden characters are rejected
- Confirmed none of those executions produce an invalid-regex diagnostic

Test environment: GNU Bash 5.3.9.
